### PR TITLE
Provide default value for scanFolder path in CreateSearch UI

### DIFF
--- a/client/src/views/CreateView.vue
+++ b/client/src/views/CreateView.vue
@@ -48,7 +48,7 @@
 
       <div class="form-group">
         <label for="scanFolder">File Filter: (for example: **/* or src/**/*.java)</label>
-        <input type="text" id="scanFolder" v-model="formData.scanFolder" placeholder="**/*">
+        <input type="text" id="scanFolder" v-model="formData.scanFolder">
       </div>
 
       <!-- <div class="form-group">
@@ -81,7 +81,7 @@ export default {
           variable: false
         },
         fileMatch: '*/**',
-        scanFolder: '',
+        scanFolder: '*/**',
         bedrockPauseTime: 2500
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
The current placeholder makes it seem like **/* is sent as the default value which then leads to confusing behavior (a job is started but no files are processed). 

*Description of changes:*
This change makes **/* a sensible default that can be changed if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
