### PR TITLE
Bugfix: Account_ID env var missing from Summarizer Lambda

### DIFF
--- a/client/src/views/CreateView.vue
+++ b/client/src/views/CreateView.vue
@@ -48,7 +48,7 @@
 
       <div class="form-group">
         <label for="scanFolder">File Filter: (for example: **/* or src/**/*.java)</label>
-        <input type="text" id="scanFolder" v-model="formData.scanFolder" placeholder="**/*">
+        <input type="text" id="scanFolder" v-model="formData.scanFolder">
       </div>
 
       <!-- <div class="form-group">
@@ -81,7 +81,7 @@ export default {
           variable: false
         },
         fileMatch: '*/**',
-        scanFolder: '',
+        scanFolder: '**/*',
         bedrockPauseTime: 2500
       }
     }

--- a/lib/code_graph_search-stack.ts
+++ b/lib/code_graph_search-stack.ts
@@ -337,6 +337,7 @@ export class CodeGraphSearchStack extends cdk.Stack {
       reservedConcurrentExecutions: 1,
     });
     codeSummarizerLambdaFunction.addEnvironment('REGION', this.region);
+    codeSummarizerLambdaFunction.addEnvironment('ACCOUNT_ID', this.account);
     codeSummarizerLambdaFunction.addEnvironment('S3_BUCKET_NAME', codeDownloadBucket.bucketName);
     codeSummarizerLambdaFunction.addEnvironment('PRIVATE_BEDROCK_DNS', `bedrock-runtime.${this.region}.amazonaws.com`);
     codeSummarizerLambdaFunction.addEnvironment('PRIVATE_NEPTUNE_DNS', neptuneCluster.attrReadEndpoint);


### PR DESCRIPTION
## Bugfix: Account_ID env var missing from Summarizer Lambda

### Problem
The Summarizer Lambda function was missing the ACCOUNT_ID environment variable, which could cause runtime issues when the function needs to reference the AWS account ID for operations. In my case the Bedrock inference profile wouldn't be constructed properly and cause Bedrock Validation Errors.

### Solution
• Added the missing ACCOUNT_ID environment variable to the codeSummarizerLambdaFunction in the CDK stack
• The environment variable is set to this.account which provides the current AWS account ID

### Changes Made
• **lib/code_graph_search-stack.ts**: Added ACCOUNT_ID environment variable to the Summarizer Lambda function
• **client/src/views/CreateView.vue**: Minor UI improvements - moved default value for scanFolder from placeholder to actual default value for better UX

### Impact
This fix ensures the Summarizer Lambda has access to the AWS account ID, preventing potential runtime errors and enabling proper AWS resource referencing.